### PR TITLE
fix layout of front panel, use shortcode for raw html

### DIFF
--- a/site/pages/pycon-thailand.en.rst
+++ b/site/pages/pycon-thailand.en.rst
@@ -1,37 +1,21 @@
 .. title: PyCon Thailand 2019
 .. slug: index
 .. date: 2019-02-17 12:20:00 UTC+07:00
-.. tags: 
-.. category: 
-.. link: 
-.. description: 
+.. tags:
+.. category:
+.. link:
+.. description:
 .. type: text
 
-.. container:: row jumbotron
+.. container:: jumbotron
 
-   .. raw:: html
+    .. class:: row
 
-       <div class="col-sm">
-          <img src="/pycon-logo.svg" alt="Pycon Thailand Logo">
-       </div>
-       <div class="col-sm"> </div>
-       <div class="col-sm">
-       <div class="container admonition admonition-pycon-thailand-2018 text-center"
-       style="    background-color: rgba(255,255,255,0.55);">
-           <h1 class="admonition-title"><a href="/">PyCon Thailand 2019</a></h1>
+        .. raw:: html
 
-           <ul class="list-inline banner-social-buttons last">
-               <li class="list-inline-item">
-                   <a href="https://twitter.com/pyconthailand" class="btn btn-default btn-lg" target="_blank"><i class="fa fa-twitter fa-fw"></i></a>
-               </li>
-               <li class="list-inline-item">
-                   <a href="https://www.facebook.com/pyconthailand/" class="btn btn-default btn-lg" target="_blank"><i class="fa fa-facebook fa-fw"></i></a>
-               </li>
-           </ul>
-       </div>
-       </div>
-       <div class="col-sm"> </div>
-      </div>
+            {{% front_panel
+                event_heading='PyCon Thailand 2019' %}}
+
 
 
 Coming soon

--- a/site/pages/pycon-thailand.th.rst
+++ b/site/pages/pycon-thailand.th.rst
@@ -7,32 +7,14 @@
 .. description:
 .. type: text
 
+.. container:: jumbotron
 
-.. container:: row jumbotron
+    .. class:: row
 
-   .. raw:: html
+        .. raw:: html
 
-       <div class="col-sm">
-          <img src="/pycon-logo.svg" alt="Pycon Thailand Logo">
-       </div>
-       <div class="col-sm"> </div>
-       <div class="col-sm">
-       <div class="container admonition admonition-pycon-thailand-2018 text-center"
-       style="    background-color: rgba(255,255,255,0.55);">
-           <h1 class="admonition-title"><a href="/">PyCon Thailand 2019</a></h1>
-        
-           <ul class="list-inline banner-social-buttons last">
-               <li class="list-inline-item">
-                   <a href="https://twitter.com/pyconthailand" class="btn btn-default btn-lg" target="_blank"><i class="fa fa-twitter fa-fw"></i></a>
-               </li>
-               <li class="list-inline-item">
-                   <a href="https://www.facebook.com/pyconthailand/" class="btn btn-default btn-lg" target="_blank"><i class="fa fa-facebook fa-fw"></i></a>
-               </li>
-           </ul>
-       </div>
-       </div>
-       <div class="col-sm"> </div>
-      </div>
+            {{% front_panel
+                event_heading='PyCon Thailand 2019' %}}
 
 
 Coming soon
@@ -43,7 +25,6 @@ Coming soon
    .. class:: col-sm
 
       Preparations for PyCon Thailand 2019 are underway, watch this space!
-
 
 
 ข่าวล่าสุด

--- a/site/shortcodes/front_panel.tmpl
+++ b/site/shortcodes/front_panel.tmpl
@@ -1,0 +1,26 @@
+<div class="col-sm-3 offset-sm-1">
+  <img class="home-logo" src="/pycon-logo.svg" alt="Pycon Thailand Logo">
+</div>
+
+<div class="col-sm-6 offset-sm-1">
+  <div class="container admonition admonition-pycon-thailand-2018 text-center"
+                    style="background-color: rgba(255,255,255,0.55);">
+
+    <h1 class="admonition-title">
+      <a href="/">${ event_heading }</a>
+    </h1>
+
+    <ul class="list-inline banner-social-buttons last">
+      <li class="list-inline-item">
+        <a href="https://twitter.com/pyconthailand" class="btn btn-secondary btn-lg" target="_blank">
+          <i class="fa fa-twitter fa-fw"/>
+        </a>
+      </li>
+      <li class="list-inline-item">
+        <a href="https://www.facebook.com/pyconthailand/" class="btn btn-secondary btn-lg" target="_blank">
+          <i class="fa fa-facebook fa-fw"/>
+        </a>
+      </li>
+    </ul>
+  </div>
+</div>

--- a/site/themes/pyconth/assets/css/custom.css
+++ b/site/themes/pyconth/assets/css/custom.css
@@ -1,3 +1,20 @@
+/* home page */
+img.home-logo {
+    max-width: 85%;
+}
+
+.admonition-title {
+    margin-top: 1rem;
+    margin-bottom: 0.75rem;
+}
+
+a.btn > i.fa {
+    font-size: 20px;
+    vertical-align: middle;
+    margin: 0.5rem 0;
+}
+
+/* navbar */
 .navbar-inverse {
     background-color: #b5a0ac;
     border-color: #511c39;
@@ -16,7 +33,7 @@ body.path-2018 header, body.path-frontpage header {
 
 /* body[class*="schedule"] table.table td { height: 1px; }
 body[class*="schedule"] table.table td span.pyladies { display: block; height: 100%; background: green; }
-*/ 
+*/
 body[class*="schedule"] table,
 body[class*="schedule"] th,
 body[class*="schedule"] td {


### PR DESCRIPTION
- `row` shouldn't be in the same level as `container`.
- `offset-sm-` should be used instead of blank `col-sm-`.
- `btn-` syntax is changed.
- `shortcodes` help to organize raw HTML used in multi-languages page better.